### PR TITLE
Refactor and Development Updates

### DIFF
--- a/contracts/BondPool.sol
+++ b/contracts/BondPool.sol
@@ -14,6 +14,8 @@ contract BondPool is IBondPool, ReentrancyGuard, Recoverable, Pausable {
 
   mapping(address => mapping(address => Bond)) public _bonds; // account -> bond token --> liquidity
   mapping(address => Pair) public _pool;
+
+  uint256 public override _totalRewardAllocation;
   uint256 public _totalNepPaired;
   address public _treasury;
 
@@ -111,6 +113,7 @@ contract BondPool is IBondPool, ReentrancyGuard, Recoverable, Pausable {
     require(maxStake > 0, "Invalid maximum stake amount");
 
     if (amount > 0) {
+      _totalRewardAllocation = _totalRewardAllocation.add(amount);
       _nepToken.safeTransferFrom(super._msgSender(), address(this), amount);
     }
 
@@ -247,7 +250,6 @@ contract BondPool is IBondPool, ReentrancyGuard, Recoverable, Pausable {
     uint256 entryFee
   ) private {
     IERC20(bondToken).safeTransferFrom(super._msgSender(), address(this), bondTokenAmount);
-
     _nepToken.approve(address(_pancakeRouter), nepAmount);
     IERC20(bondToken).approve(address(_pancakeRouter), bondTokenAmount.sub(entryFee));
   }

--- a/contracts/BondPool.sol
+++ b/contracts/BondPool.sol
@@ -383,11 +383,11 @@ contract BondPool is IBondPool, ReentrancyGuard, Recoverable, Pausable {
     _finalize(bondToken);
   }
 
-  function pause() external onlyOwner {
+  function pause() external onlyOwner whenNotPaused {
     super._pause();
   }
 
-  function unpause() external onlyOwner {
+  function unpause() external onlyOwner whenPaused {
     super._unpause();
   }
 }

--- a/contracts/IBondPool.sol
+++ b/contracts/IBondPool.sol
@@ -26,7 +26,7 @@ interface IBondPool {
 
   event PairUpdated(address indexed token, string name, uint256 maxStake, uint256 minBond, uint256 entryFee, uint256 exitFee, uint256 lockingPeriod, uint256 amount);
   event BondCreated(address indexed bondToken, uint256 nepStaked, uint256 bondTokenStaked, uint256 liquidity);
-  event BondReleased(address indexed bondToken, uint256 nepReleased, uint256 bondTokenReleased, uint256 liquidity);
+  event BondReleased(address indexed bondToken, uint256 liquidity);
 
   /**
    * @dev Gets the total number of NEP allocated to be distributed as reward
@@ -37,26 +37,15 @@ interface IBondPool {
    * @dev Gets the bond market information information
    * @param token The token address to get the information
    * @param account Enter your account address to get the information
-   * @param poolTotalNepPaired Returns the total amount of NEP paired with the given token
-   * @param totalLocked Returns the total amount of the token locked/staked in this pool
-   * @param totalLiquidity Returns the sum of liquidity (PancakeSwap LP token) locked in this pool
-   * @param releaseDate Returns the release date of the sender (if any bond)
-   * @param nepAmount Returns the sender's amount of NEP reward that was bonded with the suppplied token
-   * @param bondTokenAmount Returns the sender's token amount that was bonded with NEP
-   * @param liquidity Returns the sender's liquidity that was created and locked in the PancakeSwap exchange
+   * @param values[0] poolTotalNepPaired Returns the total amount of NEP paired with the given token
+   * @param values[1] totalLocked Returns the total amount of the token locked/staked in this pool
+   * @param values[2] releaseDate Returns the release date of the account (if any bond)
+   * @param values[3] nepAmount Returns the account's active NEP reward that was bonded with the suppplied token
+   * @param values[4] bondTokenAmount Returns the accounts's token amount that was bonded with NEP
+   * @param values[5] liquidity Returns the account's liquidity that was created and locked in the PancakeSwap exchange
+   * @param values[6] myNepRewards Returns the account's sum total NEP reward in this pool
    */
-  function getInfo(address token, address account)
-    external
-    view
-    returns (
-      uint256 poolTotalNepPaired,
-      uint256 totalLocked,
-      uint256 totalLiquidity,
-      uint256 releaseDate,
-      uint256 nepAmount,
-      uint256 bondTokenAmount,
-      uint256 liquidity
-    );
+  function getInfo(address token, address account) external view returns (uint256[] memory values);
 
   /**
    * @dev Gets the bond creation information

--- a/contracts/IBondPool.sol
+++ b/contracts/IBondPool.sol
@@ -29,6 +29,11 @@ interface IBondPool {
   event BondReleased(address indexed bondToken, uint256 nepReleased, uint256 bondTokenReleased, uint256 liquidity);
 
   /**
+   * @dev Gets the total number of NEP allocated to be distributed as reward
+   */
+  function _totalRewardAllocation() external view returns (uint256);
+
+  /**
    * @dev Gets the bond market information information
    * @param token The token address to get the information
    * @param account Enter your account address to get the information

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -11,6 +11,10 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
+    if (amount == 0) {
+      return;
+    }
+
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transfer(recipient, amount);
     uint256 post = malicious.balanceOf(recipient);
@@ -24,6 +28,10 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
+    if (amount == 0) {
+      return;
+    }
+
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transferFrom(sender, recipient, amount);
     uint256 post = malicious.balanceOf(recipient);

--- a/contracts/Libraries/NTransferUtilV1.sol
+++ b/contracts/Libraries/NTransferUtilV1.sol
@@ -11,9 +11,8 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
-    if (amount == 0) {
-      return;
-    }
+    require(recipient != address(0), "Invalid recipient");
+    require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transfer(recipient, amount);
@@ -28,9 +27,8 @@ library NTransferUtilV1 {
     address recipient,
     uint256 amount
   ) public {
-    if (amount == 0) {
-      return;
-    }
+    require(recipient != address(0), "Invalid recipient");
+    require(amount > 0, "Invalid transfer amount");
 
     uint256 pre = malicious.balanceOf(recipient);
     malicious.transferFrom(sender, recipient, amount);


### PR DESCRIPTION
- Updated library NTransferUtilV1 to ignore transfers when zero amount is sent
- Added a new variable _totalRewardAllocation on IBondPool and BondPool contracts.
- Updated _totalRewardAllocation as soon as the farm is set
- Refactored NTransferUtilV1 to revert during zero value transfers
- Refactored NTransferUtilV1 to revert transfers to the zero address
- Refactored createBond feature to check bond amounts
- Refactored createBond feature to transfer non zero amounts only
- Refactored _finalize function to simplify the implementation
- Refactored _releaseBondToSender to remove the redundant and unused return values
- Refactored releaseBond function to simplify the implementation. Moved the logic to another function _releaseBondToSenderDeductingFees
- Added checks to ensure that transfers are non zero unsigned integers
- Added `_myNepRewards` variable to keep track of total NEP rewarded to the user by any given bond token.
- Refactored `_addLiquidity` function to update `_myNepRewards` variable
- Refactored `createBond` feature to stop when the contract is paused
- Fixed bug #5. The functions `releaseBondToSender` and `releaseBondToSenderDeductingFees` now simply transfer liquidity to the wallets instead of withdrawing them from the PancakeSwap Exchange.
- Because of the return size limitation, refactored `getInfo` function to return an integer array instead of bunch of values
- Fixed bug #4. On `addOrUpdatePair`, dropped variable instantiation to instead use the state variable directly.

